### PR TITLE
Add VS Code recommended extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@
 *.app
 
 build/*
-.vscode/*
+.vscode
+!.vscode/extenstions.json
 .vs/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "ms-vscode.cpptools",
+    "twxs.cmake",
+    "ms-vscode.cmake-tools",
+    "marus25.cortex-debug",
+    "davidschuldenfrei.gtest-adapter",
+  ]
+}


### PR DESCRIPTION
Hi Daniel!

seeing this:

https://github.com/FL0WL0W/EFIGenie/blob/c1250880a27e6a48afd8e517392aa99dd657f913/README.md?plain=1#L37-L42

there is also a way to prompt the developer for installing recommended extensions, I've used this here:

https://github.com/speedy-tuner/speedy-tuner-cloud/blob/b4e7046aac98bf6de4961ae534dd1aace89d4e6e/.vscode/extensions.json

And when you open vscode it looks like this:

<img width="466" alt="Screenshot 2022-02-12 at 10 40 24" src="https://user-images.githubusercontent.com/3144291/153706220-bd5782d7-ecaa-4e0a-8134-b6a6b37599e2.png">

<img width="414" alt="Screenshot 2022-02-12 at 10 40 34" src="https://user-images.githubusercontent.com/3144291/153706223-c03322ae-c66d-440f-879c-52d8eb98b1c3.png">


